### PR TITLE
Add SSH certificate authentication for cluster nodes

### DIFF
--- a/iac_ansible/README.md
+++ b/iac_ansible/README.md
@@ -65,10 +65,35 @@ ansible-playbook -i inventory-homelab.ini install-cluster.yml --tags apt
 - `config`: Hostname and timezone configuration
 - `system`: System updates, NTP
 - `tools`: Essential CLI tools (vim, networking tools)
+- `security`: SSH certificates, step-cli
+- `ssh`: SSH certificate configuration only
+- `certificates`: SSH certificate configuration only
 - `dev`: Rust toolchain and cargo packages
 - `hardware`: I2C support, info display
 - `apt`: APT updates only
 - `cargo`: Cargo package compilation (slow on ARM)
+
+### SSH Certificate Authentication
+
+The cluster nodes can be configured to use SSH certificate-based authentication with step-ca:
+
+```bash
+# Configure SSH certificates on all cluster nodes
+ansible-playbook -i inventory-homelab.ini install-cluster.yml --tags ssh
+
+# Or include in full deployment
+./deploy-cluster.sh
+```
+
+This configuration:
+- Generates host certificates for each node using step-ca
+- Configures SSH to trust user certificates signed by the CA
+- Sets up proper principals (hostname and FQDN)
+- Automatically restarts SSH service
+
+**Prerequisites:**
+- step-ca must be running and accessible
+- step-cli must be installed on cluster nodes (included in deployment)
 
 ### Certificate Authority Setup
 

--- a/iac_ansible/install-cluster.yml
+++ b/iac_ansible/install-cluster.yml
@@ -1,6 +1,11 @@
 - name: Install basic software on cluster nodes
   hosts: cluster
   become: yes
+  handlers:
+    - name: restart ssh
+      systemd:
+        name: ssh
+        state: restarted
   tasks:
   - name: Set hostname
     hostname:
@@ -24,6 +29,9 @@
   - include_tasks: tasks/ntp-task.yml
     tags: [system, ntp]
 
+  - include_tasks: tasks/step-cli-task.yml
+    tags: [security, step-cli]
+
   - include_tasks: tasks/rust-task.yml
     tags: [dev, rust]
 
@@ -35,3 +43,6 @@
 
   - include_tasks: tasks/info-display-task.yml
     tags: [hardware, display]
+
+  - include_tasks: tasks/ssh-cert-task.yml
+    tags: [security, ssh, certificates]

--- a/iac_ansible/tasks/ssh-cert-task.yml
+++ b/iac_ansible/tasks/ssh-cert-task.yml
@@ -1,0 +1,104 @@
+---
+# Configures SSH to use certificate-based authentication with step-ca
+# Generates host certificates and configures SSH server to trust user certificates
+# Requires step-cli to be installed and configured
+
+- name: Check if step-cli is installed
+  command: which step
+  register: step_installed
+  changed_when: false
+  failed_when: false
+
+- name: Fail if step-cli is not installed
+  fail:
+    msg: "step-cli is not installed. Please install it first using step-cli-task.yml"
+  when: step_installed.rc != 0
+
+- name: Ensure SSH keys directory exists
+  file:
+    path: /etc/ssh/keys
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Check if host certificate already exists
+  stat:
+    path: /etc/ssh/keys/ssh_host_ca_key-cert.pub
+  register: host_cert_stat
+
+- name: Create temporary directory for certificate generation
+  file:
+    path: /tmp/ssh_keys_temp
+    state: directory
+    mode: '0700'
+  when: not host_cert_stat.stat.exists
+
+- name: Generate host certificate and keys (no passphrase)
+  shell: |
+    cd /tmp/ssh_keys_temp
+    step ssh certificate --host \
+      --principal {{ inventory_hostname }} \
+      --principal {{ inventory_hostname }}.metatao.net \
+      --no-password \
+      {{ inventory_hostname }} ssh_host_ca_key
+  args:
+    creates: /tmp/ssh_keys_temp/ssh_host_ca_key
+  when: not host_cert_stat.stat.exists
+  environment:
+    STEPPATH: /root/.step
+
+- name: Move generated keys to /etc/ssh/keys/
+  shell: |
+    mv /tmp/ssh_keys_temp/* /etc/ssh/keys/
+    chmod 600 /etc/ssh/keys/ssh_host_ca_key
+    chmod 644 /etc/ssh/keys/ssh_host_ca_key.pub
+    chmod 644 /etc/ssh/keys/ssh_host_ca_key-cert.pub
+    rm -rf /tmp/ssh_keys_temp
+  when: not host_cert_stat.stat.exists
+
+- name: Get trusted user CA public key from step-ca
+  shell: step ssh config --roots
+  register: user_ca_key
+  changed_when: false
+
+- name: Write trusted user CA public key
+  copy:
+    content: "{{ user_ca_key.stdout }}"
+    dest: /etc/ssh/keys/ssh_user_ca_key.pub
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Ensure sshd_config.d directory exists
+  file:
+    path: /etc/ssh/sshd_config.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Configure SSH to use certificates
+  copy:
+    content: |
+      # SSH Certificate Authentication Configuration
+      TrustedUserCAKeys /etc/ssh/keys/ssh_user_ca_key.pub
+      HostKey /etc/ssh/keys/ssh_host_ca_key
+      HostCertificate /etc/ssh/keys/ssh_host_ca_key-cert.pub
+    dest: /etc/ssh/sshd_config.d/ca_ssh.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: restart ssh
+
+- name: Validate SSH configuration
+  command: sshd -t
+  changed_when: false
+  register: sshd_test
+  failed_when: sshd_test.rc != 0
+
+- name: Restart SSH service
+  systemd:
+    name: ssh
+    state: restarted
+  when: sshd_test.rc == 0


### PR DESCRIPTION
## Summary

Adds automated SSH certificate-based authentication configuration using step-ca for all cluster nodes (white, pink, orange).

## Changes

### New Task File
- ✨ `tasks/ssh-cert-task.yml`: Automated SSH certificate setup
  - Generates host certificates using step-ca
  - Configures principals (hostname + FQDN)
  - Sets up trusted user CA keys
  - Manages SSH server configuration

### Updated Files
- 📝 `install-cluster.yml`: Added step-cli and ssh-cert tasks
- 📝 `install-cluster.yml`: Added SSH restart handler
- 📝 `README.md`: Documented SSH certificate authentication

### Key Features
- ✅ **Idempotent**: Skips certificate generation if already exists
- ✅ **No Passphrase**: Uses `--no-password` flag for unattended setup
- ✅ **Automatic Restart**: SSH service restarted after configuration
- ✅ **Proper Permissions**: Correct file modes for keys and certificates
- ✅ **Validation**: Tests SSH configuration before restarting service

## Configuration Details

**Certificate Storage:**
- Host key: `/etc/ssh/keys/ssh_host_ca_key`
- Host cert: `/etc/ssh/keys/ssh_host_ca_key-cert.pub`
- User CA: `/etc/ssh/keys/ssh_user_ca_key.pub`

**SSH Configuration:** `/etc/ssh/sshd_config.d/ca_ssh.conf`
```
TrustedUserCAKeys /etc/ssh/keys/ssh_user_ca_key.pub
HostKey /etc/ssh/keys/ssh_host_ca_key
HostCertificate /etc/ssh/keys/ssh_host_ca_key-cert.pub
```

**Principals:**
- Short name: `white`, `pink`, `orange`
- FQDN: `white.metatao.net`, `pink.metatao.net`, `orange.metatao.net`

## Usage

```bash
# Configure SSH certificates only
ansible-playbook -i inventory-homelab.ini install-cluster.yml --tags ssh

# Include in full deployment
./deploy-cluster.sh

# Skip SSH cert configuration
./deploy-cluster.sh --skip-tags ssh
```

## Prerequisites

- ✅ step-ca running and accessible
- ✅ step-cli installed (now included in cluster deployment)

## Test Plan

- [ ] Verify certificates are generated with correct principals
- [ ] Confirm SSH service restarts successfully
- [ ] Test SSH login with certificate-based authentication
- [ ] Verify idempotency (run twice, second run should skip)
- [ ] Check SSH configuration validation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)